### PR TITLE
Handle unicode in file names

### DIFF
--- a/sftpclone/sftpclone.py
+++ b/sftpclone/sftpclone.py
@@ -369,7 +369,7 @@ class SFTPClone(object):
             return
 
         # the (absolute) remote address of f.
-        remote_path = join(self.remote_path, relative_path, f)
+        remote_path = join(self.remote_path.encode('utf8'), relative_path.encode('utf8'), f)
 
         # First case: f is a directory
         if S_ISDIR(l_st.st_mode):


### PR DESCRIPTION
Yay! I figured it out. We were kind of running into the wrong direction. The environment is fine. The problem in #12 is with the `join()` statement itself.

This is fixing the problem:
`remote_path = join(self.remote_path.encode('utf8'), relative_path.encode('utf8'), f)`

The issue is, that join is fine with mixing up byte strings and unicode, but not with mixing unicode and str. This is what is happening here when the filename contains unicode.

My solution is to make sure that the str that may occur is also encoded in unicode.