### PR TITLE
Python3 fix

### DIFF
--- a/sftpclone/sftpclone.py
+++ b/sftpclone/sftpclone.py
@@ -423,7 +423,7 @@ class SFTPClone(object):
             return
 
         # the (absolute) remote address of f.
-        remote_path = join(self.remote_path, relative_path, f)
+        remote_path = join(self.remote_path.encode('utf8'), relative_path.encode('utf8'), f)
 
         # First case: f is a directory
         if S_ISDIR(l_st.st_mode):

--- a/sftpclone/sftpclone.py
+++ b/sftpclone/sftpclone.py
@@ -423,7 +423,7 @@ class SFTPClone(object):
             return
 
         # the (absolute) remote address of f.
-        remote_path = join(self.remote_path.encode('utf8'), relative_path.encode('utf8'), f)
+        remote_path = join(self.remote_path.encode('utf8'), relative_path.encode('utf8'), f.encode('utf8'))
 
         # First case: f is a directory
         if S_ISDIR(l_st.st_mode):


### PR DESCRIPTION
Well... compared to python2, python3 refuses to mix byte strings and unicode also. So we need to conver the byte string "f" also. #12 