### PR TITLE
Bump paramiko version to 2.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-paramiko==2.1.2
+paramiko==2.4.1

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author_email='adrianodl@hotmail.it',
 
     packages=['sftpclone'],
-    install_requires=['paramiko==2.1.2', ],
+    install_requires=['paramiko==2.4.1', ],
     test_suite='nose.collector',
     tests_require=['nose', 'mock', ],
     scripts=['bin/sftpclone', ],


### PR DESCRIPTION
Makes sftpclone compatible with Python 3.7.

Fixes #26.