### PR TITLE
Bump paramiko version to 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-paramiko==2.4.1
+paramiko==2.6.0


### PR DESCRIPTION
The current required version, 2.4.1, is causing a lot of deprecation warnings:
```
/usr/lib/python3.8/site-packages/paramiko/kex_ecdh_nist.py:39: CryptographyDeprecationWarning: encode_point has been deprecated on EllipticCurvePublicNumbers and will be removed in a future version. Please use EllipticCurvePublicKey.public_bytes to obtain both compressed and uncompressed point encoding.
  m.add_string(self.Q_C.public_numbers().encode_point())
/usr/lib/python3.8/site-packages/paramiko/kex_ecdh_nist.py:91: CryptographyDeprecationWarning: Support for unsafe construction of public numbers from encoded data will be removed in a future version. Please use EllipticCurvePublicKey.from_encoded_point
  self.Q_S = ec.EllipticCurvePublicNumbers.from_encoded_point(
/usr/lib/python3.8/site-packages/paramiko/kex_ecdh_nist.py:103: CryptographyDeprecationWarning: encode_point has been deprecated on EllipticCurvePublicNumbers and will be removed in a future version. Please use EllipticCurvePublicKey.public_bytes to obtain both compressed and uncompressed point encoding.
  hm.add_string(self.Q_C.public_numbers().encode_point())
```
With the latest paramiko version (2.6.0), these warnings are gone, and sftpclone still seems to work (at least during my tests). (There might be versions between 2.4.1 and 2.6.0 which also work, but I guess upgrading to the latest makes more sense.)