### PR TITLE
Added a traverse remote directories option

### DIFF
--- a/sftpclone/sftpclone.py
+++ b/sftpclone/sftpclone.py
@@ -21,8 +21,6 @@ import socket
 
 """SFTPClone: sync local and remote directories."""
 
-logger = None
-
 try:
     # Not available in Python 2.x
     FileNotFoundError
@@ -119,7 +117,7 @@ class SFTPClone(object):
     def __init__(self,
                 local_path,
                 remote_url,
-                logger,
+                logger = None,
                  identity_files=None,
                  port=None,
                  fix_symlinks=False,

--- a/sftpclone/sftpclone.py
+++ b/sftpclone/sftpclone.py
@@ -649,7 +649,7 @@ class SFTPClone(object):
                 stats["remote"], stats["deleted"] = self.check_for_deletion()
 
             # Now scan local for items to upload/create
-            stats["local"], stats["copied"] = self.check_for_upload_create()
+            self.check_for_upload_create()
 
             
         except FileNotFoundError:
@@ -657,7 +657,7 @@ class SFTPClone(object):
             self.logger.error(
                 "Error while opening remote folder. Are you sure it does exist?")
             sys.exit(1)
-            
+
         stats["local"] = self.total_local
         stats["copied"]  = self.total_copied
 

--- a/sftpclone/sftpclone.py
+++ b/sftpclone/sftpclone.py
@@ -438,7 +438,7 @@ class SFTPClone(object):
         total_deleted = 0
 
         for remote_st in self.sftp.listdir_attr(remote_path):
-            total_remote++
+            total_remote += 1
             r_lstat = self.sftp.lstat(path_join(remote_path, remote_st.filename))
 
             inner_remote_path = path_join(remote_path, remote_st.filename)
@@ -453,7 +453,7 @@ class SFTPClone(object):
 
             if self._must_be_deleted(inner_local_path, remote_st):
                 self.remote_delete(inner_remote_path, remote_st)
-                total_deleted++
+                total_deleted += 1
             elif S_ISDIR(remote_st.st_mode):
                 if self.traverse_remote_directories:
                     sub_remote, sub_deleted = self.check_for_deletion(

--- a/sftpclone/sftpclone.py
+++ b/sftpclone/sftpclone.py
@@ -652,7 +652,7 @@ class SFTPClone(object):
                 "Error while opening remote folder. Are you sure it does exist?")
             sys.exit(1)
 
-        return total_remote, total_deleted, total_copied
+        return stats
 
 
 def create_parser():

--- a/sftpclone/sftpclone.py
+++ b/sftpclone/sftpclone.py
@@ -405,6 +405,7 @@ class SFTPClone(object):
         """Upload local_path to remote_path and set permission and mtime."""
         self.sftp.put(local_path, remote_path)
         self._match_modes(remote_path, l_st)
+        self.total_copied += 1
 
     def remote_delete(self, remote_path, r_st):
         """Remove the remote directory node."""
@@ -460,6 +461,7 @@ class SFTPClone(object):
             if self._must_be_deleted(inner_local_path, remote_st):
                 self.remote_delete(inner_remote_path, remote_st)
                 self.total_deleted += 1
+
             elif S_ISDIR(remote_st.st_mode):
                 # don't count directories in file stats
                 self.total_remote -= 1 
@@ -601,7 +603,6 @@ class SFTPClone(object):
             try:
                 r_st = self.sftp.lstat(remote_path)
                 if self._file_need_upload(l_st, r_st):
-                    self.total_copied += 1
                     self.file_upload(local_path, remote_path, l_st)
             except IOError as e:
                 if e.errno == errno.ENOENT:

--- a/sftpclone/sftpclone.py
+++ b/sftpclone/sftpclone.py
@@ -484,8 +484,8 @@ class SFTPClone(object):
                     remote_path, link_destination, e))
 
     def node_check_for_upload_create(self, relative_path, f):
-        total_local  = 0
-        total_copied = 0
+        self.total_local  = 0
+        self.total_copied = 0
 
         """Check if the given directory tree node has to be uploaded/created on the remote folder."""
         if not relative_path:
@@ -597,11 +597,11 @@ class SFTPClone(object):
 
         # Third case: regular file
         elif S_ISREG(l_st.st_mode):
-            total_local +=1
+            self.total_local +=1
             try:
                 r_st = self.sftp.lstat(remote_path)
                 if self._file_need_upload(l_st, r_st):
-                    total_copied += 1
+                    self.total_copied += 1
                     self.file_upload(local_path, remote_path, l_st)
             except IOError as e:
                 if e.errno == errno.ENOENT:
@@ -610,8 +610,6 @@ class SFTPClone(object):
         # Anything else.
         else:
             self.logger.warning("Skipping unsupported file %s.", local_path)
-
-        return total_local, total_copied
 
     def check_for_upload_create(self, relative_path=None):
         """Traverse the relative_path tree and check for files that need to be uploaded/created.
@@ -643,9 +641,7 @@ class SFTPClone(object):
                 sys.exit(1)
         stats = {}
         stats["remote"]  = 0
-        stats["local"]   = 0
-        stats["deleted"] = 0
-        stats["copied"]  = 0
+        stats["deleted"]   = 0
         
         try:
             if self.delete:
@@ -661,6 +657,9 @@ class SFTPClone(object):
             self.logger.error(
                 "Error while opening remote folder. Are you sure it does exist?")
             sys.exit(1)
+            
+        stats["local"] = self.total_local
+        stats["copied"]  = self.total_copied
 
         return stats
 

--- a/sftpclone/sftpclone.py
+++ b/sftpclone/sftpclone.py
@@ -29,7 +29,6 @@ try:
 except NameError:
     FileNotFoundError = IOError
 
-
 def configure_logging(level=logging.DEBUG):
     """Configure the module logging engine."""
     if level == logging.DEBUG:
@@ -117,11 +116,19 @@ class SFTPClone(object):
 
     """The SFTPClone class."""
 
-    def __init__(self, local_path, remote_url,
-                 identity_files=None, port=None, fix_symlinks=False,
-                 ssh_config_path=None, ssh_agent=False,
-                 exclude_file=None, known_hosts_path=None,
-                 delete=True, allow_unknown=False,
+    def __init__(self,
+                local_path,
+                remote_url,
+                logger,
+                 identity_files=None,
+                 port=None,
+                 fix_symlinks=False,
+                 ssh_config_path=None,
+                 ssh_agent=False,
+                 exclude_file=None,
+                 known_hosts_path=None,
+                 delete=True,
+                 allow_unknown=False,
                  create_remote_directory=False,
                  traverse_remote_directories=True,
                  ):
@@ -626,6 +633,8 @@ class SFTPClone(object):
 
             # Now scan local for items to upload/create
             self.check_for_upload_create()
+
+            
         except FileNotFoundError:
             # If this happens, probably the remote folder doesn't exist.
             self.logger.error(

--- a/sftpclone/sftpclone.py
+++ b/sftpclone/sftpclone.py
@@ -400,10 +400,13 @@ class SFTPClone(object):
         """Remove the remote directory node."""
         # If it's a directory, then delete content and directory
         if S_ISDIR(r_st.st_mode):
-            for item in self.sftp.listdir_attr(remote_path):
-                full_path = path_join(remote_path, item.filename)
-                self.remote_delete(full_path, item)
-            self.sftp.rmdir(remote_path)
+            if self.traverse_remote_directories:
+                for item in self.sftp.listdir_attr(remote_path):
+                    full_path = path_join(remote_path, item.filename)
+                    self.remote_delete(full_path, item)
+                    self.sftp.rmdir(remote_path)
+            else:
+                self.logger.info("skipping %s as traverse_remote_directories is off", remote_path)
 
         # Or simply delete files
         else:


### PR DESCRIPTION
Excludes obviously only excludes from local. However, if you exclude a local folder and that folder exists on the remote too, it will be synchronised with local at the delete stage. I had a quick go to glob match the remote to the excludes list, but this solution solved my issue quickly.

Ideally remote would get matched to the excludes list instead of this solution.